### PR TITLE
hotfix: 이메일 확인 페이지로 이동

### DIFF
--- a/WEB(FE)/src/App.jsx
+++ b/WEB(FE)/src/App.jsx
@@ -12,6 +12,7 @@ import PostPage from './pages/PostPage';
 import WritePage from './pages/WritePage';
 import { useRef } from 'react';
 import DrawerContainer from './containers/common/DrawerContainer';
+import EmailConfirmPage from './pages/EmailConfirmPage';
 
 function App() {
   const $hamburger = useRef(null);
@@ -48,6 +49,7 @@ function App() {
           <Route path='/map' element={<MapPage />} />
           <Route path='/login' element={<LoginPage />} />
           <Route path='/register' element={<RegisterPage />} />
+          <Route path='/emailConfirm' element={<EmailConfirmPage />} />
           <Route path='/mypage' element={<MyPage />} />
         </Routes>
       </section>

--- a/WEB(FE)/src/components/auth/EmailConfirm.jsx
+++ b/WEB(FE)/src/components/auth/EmailConfirm.jsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import tw from 'tailwind-styled-components';
+
+const Wrapper = tw.div`
+flex min-h-full items-center justify-center py-12 px-4 sm:px-6 lg:px-8 my-auto
+`;
+
+const FormBlock = tw.div`
+w-full max-w-md space-y-8 border-4 rounded-xl p-20 border-green-600 
+`;
+const EmailConfirm = () => {
+  return (
+    <>
+      <Wrapper>
+        <FormBlock>
+          <p className='text-center text-3xl font-bold tracking-tight'>
+            이메일을 확인하세요
+          </p>
+          <Link to={'/'}>
+            <span className='block mx-auto text-center cursor-pointer mt-5 text-gray-400 border-b-2  hover:text-black transition-colors transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);'>
+              홈으로 가기
+            </span>
+          </Link>
+        </FormBlock>
+      </Wrapper>
+    </>
+  );
+};
+
+export default EmailConfirm;

--- a/WEB(FE)/src/containers/auth/RegisterForm.jsx
+++ b/WEB(FE)/src/containers/auth/RegisterForm.jsx
@@ -61,6 +61,7 @@ const RegisterForm = () => {
       setError('이메일을 확인하세요');
       dispatch(initializeForm('register'));
       dispatch(initializeForm('auth'));
+      navigate('/emailConfirm');
     }
   }, [auth, form, authError, dispatch]);
 

--- a/WEB(FE)/src/pages/EmailConfirmPage.jsx
+++ b/WEB(FE)/src/pages/EmailConfirmPage.jsx
@@ -1,0 +1,7 @@
+import EmailConfirm from '../components/auth/EmailConfirm';
+
+const EmailConfirmPage = () => {
+  return <EmailConfirm />;
+};
+
+export default EmailConfirmPage;


### PR DESCRIPTION
1. 이메일 확인 메시지 등 대신 이메일을 확인하도록 페이지 전체를 이동